### PR TITLE
1285 clarify READMEs

### DIFF
--- a/authorization-keys-example/README.md
+++ b/authorization-keys-example/README.md
@@ -6,9 +6,7 @@ The contract code in this example retrieves the set of authorization keys for a 
 
 Upon installation, the contract code stores the authorization keys for the installer deploy into a NamedKey. The contract also contains an entry point that returns the intersection of the caller deploy's, and installer deploy's authorization keys. The tests in this repository verify different scenarios and check the resulting intersection.
 
-<!-- TODO point to the docs when the page is live. 
-Read the [Working with Authorization Keys](./tutorial/TUTORIAL.md) tutorial for additional information.
--->
+Read the [Working with Authorization Keys](https://docs.casper.network/resources/advanced/list-auth-keys-tutorial/) tutorial for additional information.
 
 ## Running the Example Code
 

--- a/authorization-keys-example/README.md
+++ b/authorization-keys-example/README.md
@@ -1,4 +1,4 @@
-# authorization-keys-example
+# How to Use Authorization Keys
 
 This simple example demonstrates retrieving and using the authorization keys associated with a Deploy.
 

--- a/multi-sig/README.md
+++ b/multi-sig/README.md
@@ -1,11 +1,13 @@
 # Multi-signature Key Management on a Casper Network
 
->**DO NOT RUN THESE EXAMPLES ON MAINNET!** 
+>**PROCEED WITH CAUTION!** 
 >
 > Incorrect account configurations could render accounts defunct and unusable, thus losing access to all the account's CSPR.
 >
-> The session code provided in this repository SHOULD NOT be used in a production environment.
-> Test all account changes in a test environment like the Testnet.
+> Understanding the [multi-sig feature](https://docs.casper.network/resources/advanced/multi-sig/) and trying it out on Testnet before using it on Mainnet is essential.
+>
+> The session code provided in this repository SHOULD NOT be used directly in a production environment. The session code is provided as an example and needs to be modified and tested to fit your scenario.
+> 
 
 ## Introduction
 
@@ -292,7 +294,7 @@ casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 
 The `remove_account.wasm` will remove the newly added account to demonstrate the possibility of removing associated keys that may have been compromised.
 
-### REMOVE KEYS WITH CAUTION! DO NOT RUN THIS EXAMPLE ON MAINNET
+### REMOVE KEYS WITH CAUTION! TEST THIS FIRST ON THE TESTNET
 
 ```bash
 casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \

--- a/storage-example/README.md
+++ b/storage-example/README.md
@@ -1,1 +1,33 @@
-# storage-example
+# How to Read and Write to Global State
+
+This folder contains session code and unit tests demonstrating how to read and write data to global state using Rust.
+
+The [installer session code](./contract/src/main.rs) starts by installing a contract on the blockchain and saving the contract hash under a named key. Then, it creates a URef, stores the value `true` under that URef, and then stores the URef under a named key. This session code uses `runtime::put_key` and `storage::write`.
+
+The [named key session code](./client/named_key_session/src/main.rs) reads the contract hash and stored value using `runtime::get_key`. It verifies that the stored value matches the runtime argument provided using `storage::read`. 
+
+The [unit tests](./tests/src/integration_tests.rs) in this repository verify that the session code above works correctly. The tests are divided in two parts:
+
+- Testing the installation and named keys in an account's context
+- Getting the named keys and testing storage read with a session call
+
+## Running the Example Code
+
+Prepare your environment with the following:
+
+`make prepare`
+
+Build the code and run the tests:
+
+`make test`
+
+Build the code without running tests:
+
+`make build-contract`
+
+## Further Reading
+
+Visit the official Casper Network documentation for more information on:
+
+- Concepts regarding [reading and writing to the blockchain](https://docs.casper.network/concepts/design/reading-and-writing-to-the-blockchain/)
+- A tutorial on [reading and writing data to global state using Rust](https://docs.casper.network/resources/tutorials/advanced/storage-workflow/)


### PR DESCRIPTION
This PR adds:
- a README for the storage-example
- links to the [Casper docs](https://docs.casper.network/)
- a clarification Ramsin requested: "we should explain why these examples need to be used with care, not to prevent people from using them"

The corresponding ticket is in the docs repository: https://github.com/casper-network/docs/issues/1285
